### PR TITLE
feat: added Hero area

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,14 @@
-import './App.css';
-import { HomeContianer } from './components/home-container/home-container';
-import { NavBar } from './components/nav-bar/nav-bar';
+import "./App.css";
+import { DemoContainer } from "./components/demo-container/demo-container";
+import { HomeContainer } from "./components/home-container/home-container";
+import { NavBar } from "./components/nav-bar/nav-bar";
 
 function App() {
   return (
     <div className="App">
       <NavBar></NavBar>
-      <HomeContianer></HomeContianer>
+      <HomeContainer></HomeContainer>
+      <DemoContainer></DemoContainer>
     </div>
   );
 }

--- a/src/colors/colors.js
+++ b/src/colors/colors.js
@@ -1,6 +1,7 @@
 export const colors = {
     white: "#ffffff",
     gray: "#cccccc",
+    grayTint: "#cfc0cf",
     pink: "#FA78BD",
     orange0: "#FCAD70",
     orange100: "#F89346",

--- a/src/components/anchor/anchor.js
+++ b/src/components/anchor/anchor.js
@@ -1,0 +1,8 @@
+/** @jsxImportSource @emotion/react */
+import * as styles from "./styles";
+
+export function Anchor({ children, ...rest }) {
+    return (
+        <a {...rest} css={styles.anchor} target="_blank">{children}</a>
+    )
+}

--- a/src/components/anchor/styles.js
+++ b/src/components/anchor/styles.js
@@ -1,0 +1,18 @@
+import { colors } from "../../colors/colors";
+
+export const anchor = {
+    fontFamily: "Monospace",
+    fontSize: "1.25rem",
+    fontWeight: "bold",
+    border: "none",
+    borderRadius: "10px",
+    padding: ".4rem 1rem",
+    background: colors.grayTint,
+    color: colors.violet300,
+    marginBottom: "1rem",
+    cursor: "pointer",
+
+    "&:hover": {
+        background: colors.purple,
+    },
+}

--- a/src/components/demo-container/demo-container.js
+++ b/src/components/demo-container/demo-container.js
@@ -1,0 +1,14 @@
+/** @jsxImportSource @emotion/react */
+import { SideBar } from "../side-bar/side-bar";
+import { ExplosionContainer } from "../explosion-container/explosion-container";
+
+import * as styles from "./styles";
+
+export function DemoContainer() {
+    return (
+        <div css={styles.demoContainer}>
+            <ExplosionContainer></ExplosionContainer>
+            <SideBar></SideBar>
+        </div>
+    )
+}

--- a/src/components/demo-container/styles.js
+++ b/src/components/demo-container/styles.js
@@ -1,0 +1,3 @@
+export const demoContainer = {
+    display: "flex"
+}

--- a/src/components/home-container/home-container.js
+++ b/src/components/home-container/home-container.js
@@ -1,14 +1,18 @@
 /** @jsxImportSource @emotion/react */
-import { SideBar } from "../side-bar/side-bar";
-import { ExplosionContainer } from "../explosion-container/explosion-container";
 
+import { Anchor } from "../anchor/anchor";
 import * as styles from "./styles";
 
-export function HomeContianer() {
+export function HomeContainer() {
     return (
-        <div css={styles.homeContianer}>
-            <ExplosionContainer></ExplosionContainer>
-            <SideBar></SideBar>
+        <div css={styles.homeContainer}>
+            <h1><code>emojisplosion</code></h1>
+            <p>💥 Blasts 😄 emoji 😊 like 🎆 fireworks 🎇 all up in your 💻 HTML 📄 page. 😍</p>
+            <div css={styles.links}>
+                <Anchor href="https://github.com/JoshuaKGoldberg/emojisplosion">GitHub</Anchor>
+                <Anchor href="https://github.com/JoshuaKGoldberg/astro-konamimojisplosion">Astro Plugin</Anchor>
+                <Anchor href="https://github.com/JoshuaKGoldberg/typedoc-plugin-konamimojisplosion">TypeDoc Plugin</Anchor>
+            </div>
         </div>
     )
 }

--- a/src/components/home-container/styles.js
+++ b/src/components/home-container/styles.js
@@ -1,3 +1,21 @@
-export const homeContianer = {
-    display: "flex"
+export const homeContainer = {
+    alignItems: "center",
+    backgroundColor: "#333",
+    color: "#ddd",
+    display: "flex",
+    flexDirection: "column",
+    fontSize: "1rem",
+    justifyContent: "center",
+    padding: "2rem",
+    textAlign: "center",
+}
+
+export const links = {
+    display: "flex",
+    flexDirection: "column",
+    gap: "1rem",
+    margin: "2rem 1rem 1rem",
+    '@media (min-width: 819px)': {
+        "flexDirection": "row",
+    }
 }

--- a/src/components/nav-bar/nav-bar.js
+++ b/src/components/nav-bar/nav-bar.js
@@ -24,7 +24,7 @@ export function NavBar() {
                 <span css={{color: colors.green}}>i</span>
                 <span css={{color: colors.orange0}}>o</span>
                 <span css={{color: colors.pink}}>n</span>
-                {" "}Demo Site</h1>
+            </h1>
             <a href={ghLink} target="_blank" rel="noreferrer">
                 <FontAwesomeIcon icon={faGithub} css={styles.icon}/>
             </a>


### PR DESCRIPTION
Adds a main area before the demo zone that links to the main & plugin GitHub repos.

![Screenshot of the site with the new hero area before the demo zone](https://github.com/cgradeff/emojisplosion-demo/assets/3335181/edd72f85-2885-469b-b819-6dfe0be5f1a3)

@cgradeff I am very much not a designer and the things you already designed here are _way_ better than anything I could have come up with. Please berate my designs if there's anything you don't like or have a better idea for!